### PR TITLE
Add workflow for creating JKS keystore as a repo secret

### DIFF
--- a/.github/workflows/build-and-publish-prerelease-apk.yml
+++ b/.github/workflows/build-and-publish-prerelease-apk.yml
@@ -10,14 +10,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-publish-release-apk:
+  build-and-publish-prerelease-apk:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -25,19 +25,16 @@ jobs:
       - name: Generate F-Droid debug APK
         run: ./gradlew assembleFdroidDebug --stacktrace
 
-      - name: Sign APK with keystore
+      - name: Sign APK using key store from repo secrets
         uses: r0adkll/sign-android-release@v1
         id: sign_app
         with:
           releaseDirectory: app/build/outputs/apk/fdroid/debug
-          signingKeyBase64: ${{ secrets.RELEASE_SIGNING_KEY_STORE }}
-          alias: key0
-          keyStorePassword: ${{ secrets.KEY_STORE_PASS }}
-          keyPassword: ${{ secrets.KEY_STORE_PASS }}
-        env:
-          BUILD_TOOLS_VERSION: "30.0.2"
+          signingKeyBase64: ${{ secrets.APK_SIGNING_KEYSTORE_FILE }}
+          alias: mykey
+          keyStorePassword: ${{ secrets.APK_SIGNING_KEYSTORE_PASSWORD }}
 
-      - name: Publish pre-release APK
+      - name: Publish pre-release APK as Github pre-release
         uses: softprops/action-gh-release@v1
         with:
           files: ${{steps.sign_app.outputs.signedReleaseFile}}

--- a/.github/workflows/build-and-publish-release-apk.yml
+++ b/.github/workflows/build-and-publish-release-apk.yml
@@ -14,11 +14,11 @@ jobs:
   build-and-publish-release-apk:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code for app release
+      - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -26,19 +26,16 @@ jobs:
       - name: Generate release APK
         run: ./gradlew assemblePremiumRelease --stacktrace
 
-      - name: Sign APK with keystore
+      - name: Sign APK using key store from repo secrets
         uses: r0adkll/sign-android-release@v1
         id: sign_app
         with:
           releaseDirectory: app/build/outputs/apk/premium/release
-          signingKeyBase64: ${{ secrets.RELEASE_SIGNING_KEY_STORE }}
-          alias: key0
-          keyStorePassword: ${{ secrets.KEY_STORE_PASS }}
-          keyPassword: ${{ secrets.KEY_STORE_PASS }}
-        env:
-          BUILD_TOOLS_VERSION: "30.0.2"
+          signingKeyBase64: ${{ secrets.APK_SIGNING_KEYSTORE_FILE }}
+          alias: mykey
+          keyStorePassword: ${{ secrets.APK_SIGNING_KEYSTORE_PASSWORD }}
 
-      - name: Create release from APK
+      - name: Publish APK as Github release
         uses: softprops/action-gh-release@v1
         with:
           files: ${{steps.sign_app.outputs.signedReleaseFile}}

--- a/.github/workflows/create-repo-secrets.yml
+++ b/.github/workflows/create-repo-secrets.yml
@@ -1,0 +1,40 @@
+name: Create APK signing secrets
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-apk-signing-secrets:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Generate key store password and store as env variable
+        run: |
+          secret=$(dd bs=256 status=none if=/dev/urandom count=1 | tr -dc "a-zA-Z0-9")
+          echo "PASSWORD=$secret" >> "$GITHUB_ENV"
+
+      - name: Store key store password as repository secret
+        uses: action-pack/set-secret@v1
+        with:
+          name: 'APK_SIGNING_KEYSTORE_PASSWORD'
+          value: "${{ env.PASSWORD }}"
+          token: ${{ secrets.SECRETS_CREATION_TOKEN }}
+
+      - name: Create key store for APK signing
+        id: create_keystore
+        run: |
+          keytool -genkeypair -keystore temp.jks -keyalg RSA -keysize 4096 -validity 10000 -dname "cn=Orgzly Revived Developers o=Orgzly Community" -storepass:env PASSWORD -keypass:env PASSWORD
+          echo "keystore=$(openssl base64 < temp.jks | tr -d '\n')" >> "$GITHUB_OUTPUT"
+
+      - name: Store key store file as repository secret
+        uses: action-pack/set-secret@v1
+        with:
+          name: 'APK_SIGNING_KEYSTORE_FILE'
+          value: "${{steps.create_keystore.outputs.keystore}}"
+          token: ${{ secrets.SECRETS_CREATION_TOKEN }}


### PR DESCRIPTION
And polish the existing ones.

The idea is to use Github Actions to generate the key pair used for signing the APKs, and store the resulting key store as secrets in the repository, available for use by the "build and release" actions.

This way, no one contributor needs to be entrusted with the key generation, minimizing the opportunities to keep a copy of the app signing key.

The only way to read repository secrets is to create and run an Action/workflow where the secrets are printed in an obfuscated manner (to prevent Github from masking them). This can of course be done by repo/organization admins, but it is hard to do without leaving any traces.

In order to create repository secrets from a workflow, a fine-grained personal access token is required when running the "Create APK signing secrets" workflow. Since this workflow is only really intended to be run once, and then disabled (but kept as documentation), I recommend creating a very short-lived personal access token for use by this workflow.

If anyone else wants to trigger the workflow to overwrite the app signing keys, they must have repo/org admin privileges, so that they can first create a personal access token with permission to write secrets.