### PR TITLE
APK building workflow tweaks

### DIFF
--- a/.github/workflows/build-and-publish-prerelease-apk.yml
+++ b/.github/workflows/build-and-publish-prerelease-apk.yml
@@ -1,4 +1,4 @@
-name: Build and publish F-Droid pre-release debug APK
+name: Build and publish pre-release debug APK
 
 on:
   # Trigger by pushing a version tag (which are protected)
@@ -22,11 +22,18 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
-      - name: Generate F-Droid debug APK
-        run: ./gradlew assembleFdroidDebug --stacktrace
+      - name: Generate debug APK
+        run: ./gradlew assemblePremiumDebug --stacktrace
+
+      - name: Get version name from git tag
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+      - name: Rename APK file
+        run: mv app/build/outputs/apk/premium/debug/app-premium-debug.apk orgzly-revived-${{ env.VERSION }}-debug.apk
 
       - name: Publish APK as a Github pre-release artifact
         uses: softprops/action-gh-release@v1
         with:
-          files: '**/*.apk'
+          files: '*.apk'
           prerelease: true
+          draft: true

--- a/.github/workflows/build-and-publish-release-apk.yml
+++ b/.github/workflows/build-and-publish-release-apk.yml
@@ -1,4 +1,4 @@
-name: Build and publish F-Droid release APK
+name: Build and publish release APK
 
 on:
   # Trigger by pushing a version tag (which are protected)
@@ -23,20 +23,27 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
-      - name: Generate F-Droid release APK
-        run: ./gradlew assembleFdroidRelease --stacktrace
+      - name: Generate release APK
+        run: ./gradlew assemblePremiumRelease --stacktrace
 
       - name: Sign APK using key store from repo secrets
         uses: kevin-david/zipalign-sign-android-release@v1.1.1
-        id: sign_app
+        id: sign_apk
         with:
-          releaseDirectory: app/build/outputs/apk/fdroid/release
+          releaseDirectory: app/build/outputs/apk/premium/release
           signingKeyBase64: ${{ secrets.APK_SIGNING_KEYSTORE_FILE }}
           alias: mykey
           keyStorePassword: ${{ secrets.APK_SIGNING_KEYSTORE_PASSWORD }}
           zipAlign: true
 
+      - name: Get version name from git tag
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+      - name: Rename APK file
+        run: mv ${{steps.sign_apk.outputs.signedReleaseFile}} orgzly-revived-${{ env.VERSION }}.apk
+
       - name: Publish APK as a Github release artifact
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{steps.sign_app.outputs.signedReleaseFile}}
+          files: '*.apk'
+          draft: true


### PR DESCRIPTION
- Always build "premium" (Play store) APK, for both debug and release
- Rename both debug and release APK artifacts according to the current version
- Always create Github releases as "drafts"